### PR TITLE
Add EDGAR Change Interpreter prompt bundle, examples, rubric, optional manifest, and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+__pycache__/
+*.pyc
+venv/
+.env

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# EDGAR Change Interpreter
+
+EDGAR Change Interpreter is a prompt bundle that prioritizes **change over summary** and **evidence over narrative** for SEC filings. Paste a filing excerpt (10-K/10-Q/8-K) and get a structured, auditable “material change” analysis with quotes, confidence ratings, and follow-up questions.
+
+## Quickstart
+1. Open `prompts/system.txt` and `prompts/user_template.md`.
+2. Paste `system.txt` into Claude as the system prompt.
+3. Paste the filled `user_template.md` into Claude as the user message (include filing text).
+4. Receive output that follows `prompts/output_template.md`.
+
+## Using it with or without a prior filing
+- **With prior filing:** Paste the prior filing excerpt into the `Prior filing text` block. The skill will compare and highlight deltas.
+- **Without prior filing:** Leave the prior block empty. The skill will avoid claiming changes vs. a missing prior period and treat the filing as a single snapshot.
+
+## Optional manifest packs (decision evidence)
+The repository includes an **optional** manifest schema at `manifest_optional/cmdrvl_manifest.schema.json`. It is **not required** for the skill to work. Use it only if you want to attach a structured “decision evidence pack” alongside the prompt to standardize metadata like lineage, refresh cadence, and known failure modes.
+
+## Optional CLI (prompt assembler)
+A tiny Python CLI assembles the system prompt + user template into a single markdown output. It does **not** call any APIs.
+
+```bash
+python tools/cli/edgar_prompt.py --current path/to/current.txt --prior path/to/prior.txt > prompt.md
+```
+
+Without a prior filing:
+
+```bash
+python tools/cli/edgar_prompt.py --current path/to/current.txt > prompt.md
+```
+
+## Contributing: add new profiles later
+To extend this skill for other asset-class profiles (e.g., credit, macro, sector-specific overlays):
+1. Add a new prompt bundle in `prompts/` (e.g., `system_credit.txt`, `user_template_credit.md`).
+2. Add an output template aligned to the new system prompt.
+3. Provide at least one example in `examples/` and update the rubric if new evaluation criteria are needed.
+
+## Disclaimer
+This project is for informational purposes only and is **not investment advice**.

--- a/examples/10k_single_filing.md
+++ b/examples/10k_single_filing.md
@@ -1,0 +1,79 @@
+# Example: 10-K Single Filing (No Prior)
+
+## Mocked filing excerpt (current 10-K)
+```
+Annual Report (Form 10-K)
+Risk Factors
+We now depend on a single third-party manufacturer for our core device, and any disruption could halt shipments for up to six months.
+
+Liquidity and Capital Resources
+We entered into a new $75.0 million term loan that matures in 2029 and bears interest at SOFR plus 450 basis points. The agreement requires maintaining a minimum liquidity balance of $20.0 million.
+
+Note 8 — Debt
+The term loan includes a springing financial covenant tied to minimum EBITDA if liquidity falls below $20.0 million.
+```
+
+## Good output (follows template)
+# EDGAR Change Interpreter Output
+
+## 1. Material Changes (Top 5–10)
+- Change: Reliance on a single third-party manufacturer is emphasized as a key risk.
+  Evidence (<=25 words): "depend on a single third-party manufacturer for our core device"
+  Fact: The company depends on one manufacturer for its core device.
+  Interpretation: Supply chain concentration increases operational risk.
+  Alternative explanations: Temporary consolidation while onboarding additional suppliers.
+  Confidence: Med
+- Change: New term loan with specific pricing and liquidity requirement is disclosed.
+  Evidence (<=25 words): "entered into a new $75.0 million term loan"
+  Fact: A $75.0 million term loan exists with SOFR+450 bps pricing.
+  Interpretation: Capital structure now includes a sizable term loan with covenant constraints.
+  Alternative explanations: Proactive refinancing for growth initiatives.
+  Confidence: High
+- Change: Springing covenant tied to liquidity and EBITDA is specified.
+  Evidence (<=25 words): "springing financial covenant tied to minimum EBITDA"
+  Fact: The term loan adds a springing financial covenant triggered by low liquidity.
+  Interpretation: Covenant risk increases if liquidity dips.
+  Alternative explanations: Standard lender protection with low likelihood of trigger.
+  Confidence: Med
+
+## 2. Silent Risk Signals
+- Signal: Minimum liquidity requirement of $20.0 million.
+  Evidence (<=25 words): "requires maintaining a minimum liquidity balance of $20.0 million"
+  Why it matters: Falling below this threshold could trigger covenants or lender actions.
+  Confidence: Med
+
+## 3. Numbers that moved (and what they might not mean)
+- Metric: Term loan size and interest rate.
+  Evidence (<=25 words): "new $75.0 million term loan" 
+  Change summary: A $75.0 million term loan at SOFR+450 bps is in place.
+  What it might not mean: Imminent distress if the loan funds planned investments.
+  Confidence: Med
+
+## 4. 8-K Item Summary (if 8-K)
+- Item: Not applicable.
+  Evidence (<=25 words): "Annual Report (Form 10-K)"
+  Impact summary: This filing is a 10-K, so no 8-K items apply.
+  Confidence: High
+
+## 5. Follow-up Checklist (next 30 minutes)
+- Task: Identify supplier concentration mitigation steps.
+  Why: Assess whether alternate manufacturers are being qualified.
+- Task: Review term loan use of proceeds.
+  Why: Clarify whether debt funds growth or covers operating needs.
+- Task: Confirm covenant trigger mechanics and testing frequency.
+  Why: Understand how quickly a liquidity dip could restrict operations.
+
+## 6. Open Questions / Missing Evidence
+- Question: What portion of device volume is covered by backup suppliers?
+  Missing evidence needed: Supplier diversification disclosures or procurement notes.
+
+## 7. Appendix: Change Map
+- Section: Risk Factors
+  Change notes: Supply chain concentration highlighted.
+  Evidence (<=25 words): "depend on a single third-party manufacturer"
+- Section: Liquidity and Capital Resources
+  Change notes: New term loan with liquidity covenant.
+  Evidence (<=25 words): "new $75.0 million term loan"
+- Section: Note 8 — Debt
+  Change notes: Springing covenant tied to EBITDA when liquidity is low.
+  Evidence (<=25 words): "springing financial covenant tied to minimum EBITDA"

--- a/examples/10q_with_prior.md
+++ b/examples/10q_with_prior.md
@@ -1,0 +1,102 @@
+# Example: 10-Q with Prior Filing
+
+## Mocked filing excerpt (current 10-Q)
+```
+Quarterly Report (Form 10-Q)
+Liquidity and Capital Resources
+We ended the quarter with $42.3 million in cash and cash equivalents, down from $58.7 million at year-end. Operating cash flow was negative $18.4 million, driven by higher inventory purchases. We drew $15.0 million on our revolving credit facility, which now has $35.0 million outstanding.
+
+Risk Factors
+We are now subject to a Department of Labor inquiry regarding wage practices at two distribution centers. An adverse outcome could require additional accruals.
+
+Controls and Procedures
+Management identified a material weakness in revenue cutoff controls related to bundled service contracts. Remediation is underway.
+```
+
+## Mocked filing excerpt (prior 10-K)
+```
+Liquidity and Capital Resources
+We ended the year with $58.7 million in cash and cash equivalents. Operating cash flow was positive $6.2 million. We had no borrowings outstanding under our revolving credit facility.
+
+Risk Factors
+We face ongoing regulatory scrutiny in multiple jurisdictions.
+
+Controls and Procedures
+Management concluded that disclosure controls and procedures were effective as of year-end.
+```
+
+## Good output (follows template)
+# EDGAR Change Interpreter Output
+
+## 1. Material Changes (Top 5–10)
+- Change: Cash balance declined and operating cash flow turned negative.
+  Evidence (<=25 words): "ended the quarter with $42.3 million in cash and cash equivalents, down from $58.7 million"
+  Fact: Cash and cash equivalents decreased to $42.3 million; operating cash flow is negative.
+  Interpretation: Liquidity tightened versus year-end, potentially from inventory build.
+  Alternative explanations: Seasonal working-capital needs; timing of customer receipts.
+  Confidence: High
+- Change: New borrowing under the revolver where prior period had none.
+  Evidence (<=25 words): "drew $15.0 million on our revolving credit facility, which now has $35.0 million outstanding"
+  Fact: Revolving credit balance is now $35.0 million outstanding.
+  Interpretation: Company is relying more on debt to fund operations.
+  Alternative explanations: Short-term bridge for planned purchases.
+  Confidence: High
+- Change: New specific regulatory inquiry disclosed.
+  Evidence (<=25 words): "subject to a Department of Labor inquiry regarding wage practices"
+  Fact: A Department of Labor inquiry is ongoing.
+  Interpretation: Regulatory risk has become more specific and potentially escalated.
+  Alternative explanations: Routine inquiry without material impact.
+  Confidence: Med
+- Change: Material weakness newly identified in revenue cutoff controls.
+  Evidence (<=25 words): "identified a material weakness in revenue cutoff controls"
+  Fact: Management identified a material weakness related to bundled service contracts.
+  Interpretation: Control environment deteriorated versus prior conclusion of effectiveness.
+  Alternative explanations: More rigorous testing uncovered issues previously undiscovered.
+  Confidence: High
+
+## 2. Silent Risk Signals
+- Signal: Negative operating cash flow alongside higher inventory purchases.
+  Evidence (<=25 words): "Operating cash flow was negative $18.4 million, driven by higher inventory purchases."
+  Why it matters: Inventory build could signal demand uncertainty or potential obsolescence risk.
+  Confidence: Med
+
+## 3. Numbers that moved (and what they might not mean)
+- Metric: Cash and cash equivalents.
+  Evidence (<=25 words): "ended the quarter with $42.3 million in cash and cash equivalents"
+  Change summary: Cash decreased from year-end $58.7 million to $42.3 million.
+  What it might not mean: A sustained liquidity crisis if the decline is seasonal.
+  Confidence: Med
+- Metric: Revolving credit outstanding.
+  Evidence (<=25 words): "now has $35.0 million outstanding"
+  Change summary: Revolver balance increased from zero to $35.0 million.
+  What it might not mean: Long-term leverage increase if repaid in subsequent quarters.
+  Confidence: Med
+
+## 4. 8-K Item Summary (if 8-K)
+- Item: Not applicable.
+  Evidence (<=25 words): "Quarterly Report (Form 10-Q)"
+  Impact summary: This filing is a 10-Q, so no 8-K items apply.
+  Confidence: High
+
+## 5. Follow-up Checklist (next 30 minutes)
+- Task: Locate details on inventory composition and aging.
+  Why: Assess whether inventory build is strategic or indicates slow-moving stock.
+- Task: Check revolver terms and covenants.
+  Why: Increased borrowings may affect liquidity headroom.
+- Task: Identify remediation plan milestones for the material weakness.
+  Why: Control fixes impact revenue recognition reliability.
+
+## 6. Open Questions / Missing Evidence
+- Question: Has the Department of Labor inquiry resulted in any accrual or estimate range?
+  Missing evidence needed: Notes on contingencies or legal proceedings.
+
+## 7. Appendix: Change Map
+- Section: Liquidity and Capital Resources
+  Change notes: Cash down, operating cash flow negative, revolver balance added.
+  Evidence (<=25 words): "cash and cash equivalents, down from $58.7 million at year-end"
+- Section: Risk Factors
+  Change notes: New specific Department of Labor inquiry disclosed.
+  Evidence (<=25 words): "subject to a Department of Labor inquiry"
+- Section: Controls and Procedures
+  Change notes: Material weakness identified; prior period stated effectiveness.
+  Evidence (<=25 words): "identified a material weakness in revenue cutoff controls"

--- a/examples/8k_items.md
+++ b/examples/8k_items.md
@@ -1,0 +1,92 @@
+# Example: 8-K Items
+
+## Mocked filing excerpt (current 8-K)
+```
+Current Report (Form 8-K)
+Item 1.01 Entry into a Material Definitive Agreement
+On September 4, 2025, the Company entered into a Supply Agreement with Orion Components. The agreement requires minimum annual purchases of $120 million and includes a 3-year term.
+
+Item 2.03 Creation of a Direct Financial Obligation
+On September 5, 2025, the Company issued $50 million of senior secured notes due 2028 with a fixed coupon of 9.5%.
+
+Item 2.05 Costs Associated with Exit or Disposal Activities
+The Company approved a restructuring plan to close its Dayton facility, with expected charges between $12 million and $15 million, primarily severance and lease termination.
+```
+
+## Good output (follows template)
+# EDGAR Change Interpreter Output
+
+## 1. Material Changes (Top 5–10)
+- Change: Entered a new supply agreement with minimum purchase commitments.
+  Evidence (<=25 words): "entered into a Supply Agreement with Orion Components"
+  Fact: A supply agreement with minimum annual purchases of $120 million was signed.
+  Interpretation: The company is locking in supply at the cost of volume commitments.
+  Alternative explanations: Securing capacity for anticipated demand growth.
+  Confidence: High
+- Change: Issued $50 million of senior secured notes with a 9.5% coupon.
+  Evidence (<=25 words): "issued $50 million of senior secured notes due 2028"
+  Fact: The company issued $50 million of senior secured notes due 2028.
+  Interpretation: Financing costs increased due to high fixed coupon.
+  Alternative explanations: Opportunistic financing to extend maturities.
+  Confidence: High
+- Change: Approved restructuring to close the Dayton facility with charges.
+  Evidence (<=25 words): "approved a restructuring plan to close its Dayton facility"
+  Fact: The Dayton facility will be closed with expected charges of $12–$15 million.
+  Interpretation: Operational footprint is being reduced.
+  Alternative explanations: Consolidation for efficiency rather than demand weakness.
+  Confidence: High
+
+## 2. Silent Risk Signals
+- Signal: Minimum purchase commitment of $120 million.
+  Evidence (<=25 words): "requires minimum annual purchases of $120 million"
+  Why it matters: Commitments could pressure margins if demand softens.
+  Confidence: Med
+
+## 3. Numbers that moved (and what they might not mean)
+- Metric: Restructuring charges.
+  Evidence (<=25 words): "expected charges between $12 million and $15 million"
+  Change summary: Restructuring charges of $12–$15 million are expected.
+  What it might not mean: A long-term decline if closure is a one-time optimization.
+  Confidence: Med
+- Metric: New secured notes issuance.
+  Evidence (<=25 words): "issued $50 million of senior secured notes due 2028"
+  Change summary: $50 million of secured debt added at 9.5%.
+  What it might not mean: Immediate liquidity strain if proceeds fund restructuring.
+  Confidence: Med
+
+## 4. 8-K Item Summary (if 8-K)
+- Item: 1.01 Entry into a Material Definitive Agreement.
+  Evidence (<=25 words): "entered into a Supply Agreement with Orion Components"
+  Impact summary: Adds minimum purchase commitments for three years.
+  Confidence: High
+- Item: 2.03 Creation of a Direct Financial Obligation.
+  Evidence (<=25 words): "issued $50 million of senior secured notes due 2028"
+  Impact summary: Adds secured debt with a 9.5% fixed coupon.
+  Confidence: High
+- Item: 2.05 Costs Associated with Exit or Disposal Activities.
+  Evidence (<=25 words): "approved a restructuring plan to close its Dayton facility"
+  Impact summary: Closure expected to incur $12–$15 million charges.
+  Confidence: High
+
+## 5. Follow-up Checklist (next 30 minutes)
+- Task: Review the supply agreement for pricing or indexation terms.
+  Why: Minimum purchases may include pricing escalators.
+- Task: Confirm use of proceeds for the secured notes.
+  Why: Determine whether financing supports restructuring or growth.
+- Task: Identify timeline and severance assumptions for the Dayton closure.
+  Why: Validate restructuring cost range.
+
+## 6. Open Questions / Missing Evidence
+- Question: Are there termination penalties or change-of-control clauses in the supply agreement?
+  Missing evidence needed: Detailed contract terms.
+
+## 7. Appendix: Change Map
+- Section: Item 1.01
+  Change notes: New supply agreement with minimum purchases.
+  Evidence (<=25 words): "Supply Agreement with Orion Components"
+- Section: Item 2.03
+  Change notes: New secured notes issued.
+  Evidence (<=25 words): "issued $50 million of senior secured notes"
+- Section: Item 2.05
+  Change notes: Facility closure and restructuring charges.
+  Evidence (<=25 words): "restructuring plan to close its Dayton facility"

--- a/manifest_optional/cmdrvl_manifest.schema.json
+++ b/manifest_optional/cmdrvl_manifest.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Decision Evidence Pack Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "dataset_id",
+    "title",
+    "domain",
+    "decision_contexts",
+    "time_axes",
+    "refresh_cadence",
+    "lineage",
+    "units",
+    "known_failure_modes",
+    "recommended_overlays",
+    "agent_affordances"
+  ],
+  "properties": {
+    "dataset_id": {
+      "type": "string",
+      "description": "Stable identifier for the evidence pack."
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable name for the pack."
+    },
+    "domain": {
+      "type": "string",
+      "description": "Domain focus, e.g., SEC filings, credit, supply chain."
+    },
+    "decision_contexts": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Decisions this pack is intended to support."
+    },
+    "time_axes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Relevant time dimensions, e.g., quarterly, annual, event-driven."
+    },
+    "refresh_cadence": {
+      "type": "string",
+      "description": "Update frequency or event trigger."
+    },
+    "lineage": {
+      "type": "string",
+      "description": "Source and transformation notes."
+    },
+    "units": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Key measurement units used in the data."
+    },
+    "known_failure_modes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Known gaps or failure cases."
+    },
+    "recommended_overlays": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Complementary data sources to cross-check."
+    },
+    "agent_affordances": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Suggested agent behaviors or tools to apply."
+    }
+  }
+}

--- a/prompts/output_template.md
+++ b/prompts/output_template.md
@@ -1,0 +1,41 @@
+# EDGAR Change Interpreter Output
+
+## 1. Material Changes (Top 5–10)
+- Change: 
+  Evidence (<=25 words): ""
+  Fact:
+  Interpretation:
+  Alternative explanations:
+  Confidence: High/Med/Low
+
+## 2. Silent Risk Signals
+- Signal:
+  Evidence (<=25 words): ""
+  Why it matters:
+  Confidence: High/Med/Low
+
+## 3. Numbers that moved (and what they might not mean)
+- Metric:
+  Evidence (<=25 words): ""
+  Change summary:
+  What it might not mean:
+  Confidence: High/Med/Low
+
+## 4. 8-K Item Summary (if 8-K)
+- Item:
+  Evidence (<=25 words): ""
+  Impact summary:
+  Confidence: High/Med/Low
+
+## 5. Follow-up Checklist (next 30 minutes)
+- Task:
+  Why:
+
+## 6. Open Questions / Missing Evidence
+- Question:
+  Missing evidence needed:
+
+## 7. Appendix: Change Map
+- Section:
+  Change notes:
+  Evidence (<=25 words): ""

--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -1,0 +1,22 @@
+You are the EDGAR Change Interpreter. Your job is to extract and explain material changes from SEC filings, prioritizing change over summary and evidence over narrative.
+
+Strict rules:
+- Focus on what changed vs prior filing if a prior filing is provided.
+- If no prior filing is provided, do NOT infer comparisons or claim changes relative to an unstated prior period.
+- For every material change, include an evidence quote of 25 words or fewer from the filing text.
+- Separate Fact vs Interpretation vs Alternative explanations.
+- Provide a confidence rating: High, Med, or Low.
+- No investment advice, no price targets, no recommendations to buy/sell/hold.
+- If the filing is an 8-K, include the 8-K Item Summary section; otherwise include the section but state “Not applicable” with a brief note.
+- Output must follow the exact section order and headings in prompts/output_template.md.
+- Keep language precise, auditable, and grounded in the provided text only.
+
+When prior filing text is provided:
+- Compare the current filing to the prior filing and highlight additions, removals, shifts in tone, and numerical changes.
+- If a claimed change lacks explicit evidence, lower confidence and call out missing evidence in Open Questions.
+
+When prior filing text is not provided:
+- Treat the filing as a single snapshot.
+- Use “Material Changes” to capture new or emphasized statements within the current filing, but do not claim they changed from prior.
+
+Return only the completed output template. Do not add extra sections or commentary.

--- a/prompts/user_template.md
+++ b/prompts/user_template.md
@@ -1,0 +1,27 @@
+# EDGAR Change Interpreter — User Input Template
+
+## Optional decision context
+- Decision goal (optional): 
+- Time horizon (optional): 
+- Risk tolerance (optional): 
+
+## Company metadata
+- Company name: 
+- Ticker (optional): 
+- Filing type (10-K / 10-Q / 8-K): 
+- Filing date: 
+- Fiscal period end (if applicable): 
+
+## Current filing text
+Paste the current filing excerpt below.
+
+```
+[CURRENT_FILING_TEXT]
+```
+
+## Prior filing text (optional)
+If you have the prior filing, paste the relevant comparable excerpt below. If not available, leave empty.
+
+```
+[PRIOR_FILING_TEXT]
+```

--- a/rubric/scoring_rubric.md
+++ b/rubric/scoring_rubric.md
@@ -1,0 +1,19 @@
+# EDGAR Change Interpreter — Scoring Rubric
+
+## Evidence discipline
+- Each material change includes a <=25-word quote.
+- Quotes clearly support the stated change.
+
+## Uncertainty discipline
+- Confidence ratings are present and sensible.
+- Open questions highlight missing evidence instead of guessing.
+
+## Change focus
+- Emphasizes deltas and shifts, not generic summaries.
+- Avoids claiming prior-period changes when no prior filing is provided.
+
+## Actionable checklist
+- Follow-up items are concrete and investigable within 30 minutes.
+
+## No hallucinated comparisons
+- Comparisons are explicitly supported by provided prior filing text.

--- a/tools/cli/edgar_prompt.py
+++ b/tools/cli/edgar_prompt.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Assemble the EDGAR Change Interpreter prompt bundle.
+
+Reads a current filing text file and an optional prior filing text file,
+then fills prompts/user_template.md and prints system + user prompt to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def build_prompt(system_path: Path, user_template_path: Path, current: str, prior: str) -> str:
+    system_prompt = read_text(system_path)
+    user_template = read_text(user_template_path)
+    filled_user = (
+        user_template.replace("[CURRENT_FILING_TEXT]", current)
+        .replace("[PRIOR_FILING_TEXT]", prior)
+    )
+    return f"# System Prompt\n\n{system_prompt}\n\n# User Prompt\n\n{filled_user}\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Assemble EDGAR Change Interpreter prompts.")
+    parser.add_argument("--current", required=True, help="Path to current filing text file.")
+    parser.add_argument("--prior", help="Path to prior filing text file (optional).")
+    parser.add_argument(
+        "--system",
+        default="prompts/system.txt",
+        help="Path to system prompt (default: prompts/system.txt).",
+    )
+    parser.add_argument(
+        "--template",
+        default="prompts/user_template.md",
+        help="Path to user template (default: prompts/user_template.md).",
+    )
+    args = parser.parse_args()
+
+    current_text = read_text(Path(args.current))
+    prior_text = read_text(Path(args.prior)) if args.prior else ""
+
+    output = build_prompt(Path(args.system), Path(args.template), current_text, prior_text)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Ship a v0 “Claude skill” that turns an SEC filing excerpt into a structured, auditable material-change analysis.  
- Prioritize change over summary and evidence over narrative with strict rules to reduce hallucination risk.  
- Make the skill usable out-of-the-box without external APIs or proprietary dependencies.  
- Provide an optional manifest and a tiny prompt-assembler CLI to support integration and reproducible prompting.

### Description
- Add core prompt files: `prompts/system.txt` with strict rules, `prompts/user_template.md` for user input, and `prompts/output_template.md` for exact output structure.  
- Add a concise evaluation rubric at `rubric/scoring_rubric.md` and three copy-pasteable example runs in `examples/` that include mocked filing excerpts and model outputs.  
- Include an optional JSON manifest schema at `manifest_optional/cmdrvl_manifest.schema.json` and repository metadata files `README.md`, `LICENSE`, and `.gitignore`.  
- Provide a minimal, dependency-free Python CLI `tools/cli/edgar_prompt.py` that assembles the system prompt + filled user template into a single markdown prompt for local use.

### Testing
- Automated tests: none were included or executed for this PR.  
- No CI or unit tests are present in the repository at this time.  
- The change is documentation- and content-focused; future PRs should add automated checks (linting, schema validation, and CLI smoke tests).  
- Manual verification was used to ensure files render and the CLI is executable (no automated run recorded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f2bcb0718832180eeb6f0c4fea6c7)